### PR TITLE
Initialized variables that were missing.

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -63,6 +63,8 @@ class VenstarColorTouch:
         self.cooltemp = None
         self.fan = None
         self.mode = None
+        self.fanstate = None
+        self.state = None
         #
         # /settings
         #
@@ -72,6 +74,7 @@ class VenstarColorTouch:
         self.schedule = None
         self.hum_setpoint = None
         self.dehum_setpoint = None
+        self.hum_active = None
 
     def login(self):
         r = self._request("/")


### PR DESCRIPTION
Somehow this wasn't a problem when i was testing before, but now that this is being used in the actual release of home-assistant, not having these variables explicitly called out in the constructor is proving to be an issue.  Can we do a 0.6? I'll then do a PR to get that into Hass.  There is normally a patch that goes out relatively quick after each release- so hopefully i can get that in!