### PR TITLE
Do not unconditionally activate schedule when disabling away mode

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -297,12 +297,6 @@ class VenstarColorTouch:
                 else:
                     print("set_away Fail {0}.".format(r.json()))
                     ret = False
-
-        #
-        # If thermostat is in away mode, then can't enable schedule.
-        #
-        if self.away == 0:
-            self.set_schedule(1)
         return ret
 
     #


### PR DESCRIPTION
Unconditionally re-enabling the schedule upon disabling away mode creates an issue where the previous hold setpoint is lost. Therefore, this change removes the call to set_schedule upon disabling away_mode.