### PR TITLE
Support Venstar T2xxx series thermostats, refactor to use Python logging class

### DIFF
--- a/src/venstarcolortouch/__main__.py
+++ b/src/venstarcolortouch/__main__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os,sys
+import logging
 import venstarcolortouch
 import time
 
@@ -7,6 +8,9 @@ def usage():
     print("Usage: {0} <ip addr>".format(sys.argv[0]))
 
 def test():
+    # Initialize logging with level DEBUG
+    logging.basicConfig(level=logging.DEBUG)
+
     if len(sys.argv) < 1:
         usage()
         return False


### PR DESCRIPTION
This commit refactors the logging output to utilize the Python standard library logging class, as well as adds support for correctly detecting the temperature units used by the local API, based off of information provided by Venstar technical support:


```
From: Alex Garashin <a.garashin@venstar.com>
Tue, Feb 26, 1:47 PM
To: nashkaminski[at]kaminski.io, thermostatsupport

Hi Nash,
The T2000 API will only display the units in Celsius. Future API updates/release will display the local API units in Celsius only as well.

Let us know if you have any further questions.

Thank You
Venstar Technical Support
```