### PR TITLE
The model check broke my venstar

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -95,7 +95,10 @@ class VenstarColorTouch:
         if j["api_ver"] >= MIN_API_VER:
             self._api_ver = j["api_ver"]
             self._type = j["type"]
-            self.model = j["model"]
+            if "model" in j:
+                self.model = j["model"]
+            else:
+                self.model = "COLORTOUCH"
             return True
         else:
             self.log.error("Unsupported API version: %s", j["api_ver"])


### PR DESCRIPTION
This defaults it to the COLORTOUCH if "model" isn't present.  (it's not on v3 api, but everything else works, so, whatever)