### PR TITLE
Add get_api_ver and get_type to expose underlying private values.

### DIFF
--- a/src/venstarcolortouch/__init__.py
+++ b/src/venstarcolortouch/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "0.14"
+__version__ = "0.15"
 
 __uri__ = 'https://github.com/hpeyerl/venstar_colortouch'
 __title__ = "venstarcolortouch"

--- a/src/venstarcolortouch/__main__.py
+++ b/src/venstarcolortouch/__main__.py
@@ -81,6 +81,9 @@ def test():
     ct.update_info()
     print("Heat setpoint is {h}\nCool setpoint is {c}\n".format(h=ct.get_info("heattemp"),c=ct.get_info("cooltemp")))
 
+    print("API Version is {v}".format(v=ct.get_api_ver()))
+    print("Thermostat Type is {t}".format(t=ct.get_type()))
+
     return True
 
 test()

--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -260,6 +260,12 @@ class VenstarColorTouch:
     def get_info(self, attr):
         return self._info[attr]
 
+    def get_api_ver(self):
+        return self._api_ver
+
+    def get_type(self):
+        return self._type
+
     def get_sensor(self, name, attr):
         if self._sensors != None and self._sensors["sensors"] != None and len(self._sensors["sensors"]) > 0:
             for sensor in self._sensors["sensors"]:


### PR DESCRIPTION
Also bumps to 0.15.  I'd like to use these in the HA integration, without having to directly access the private class members.