### PR TITLE
use celsius for t3xxx models

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -216,13 +216,13 @@ class VenstarColorTouch:
         self.sp_max = self.get_info("heattempmax")
 
         #
-        # T2xxx thermostats (and maybe more) always use Celsius in the API regardless of the display units
+        # T2xxx, T3xxx thermostats (and maybe more) always use Celsius in the API regardless of the display units
         # So handle this case accordingly
-        if "T2" in self.model:
+        if self.model.startswith(("T2", "T3")):
             # Always degC
             self.tempunits = self.TEMPUNITS_C
             logging.debug("Detected thermostat model %s, using temp units of Celsius", self.model)
-        elif self.model == "VYG-4900-VEN" or self.model == "VYG-4800-VEN"  or self.model == "VYG-3900" or self.model == "COLORTOUCH":
+        elif self.model in ["VYG-4900-VEN", "VYG-4800-VEN", "VYG-3900", "COLORTOUCH"]:
             # Same as display units
             self.tempunits = self.get_info("tempunits")
         elif self.get_info("heattempmax") >= 40:


### PR DESCRIPTION
Great library! Currently using with Home Assistant but my logs are being spammed with

```
2022-05-06 22:52:04 WARNING (SyncWorker_15) [root] Unknown thermostat model T3950R, inferring API tempunits of Celsius
```

I've tested changing the `tempunits` setting between both `0` and `1` on this model and the API always returns the values in Celsius. So I added `T3` to your existing check of whether `T2` is in the model name (actually, I've narrowed the check down to whether the model name starts with that string, not just contains it).

I've also reduced the "unknown model" logs to the info level to avoid spamming others' logs. The assumption being: if someone's thermostat is reporting incorrect units, they'll increase their log level when troubleshooting and then they'll be able to see that message.