### PR TITLE
get_settings: handle api returning None

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -269,7 +269,7 @@ class VenstarColorTouch:
         if not r:
             return None
 
-        setting = r.json()[attr]
+        setting = r.json().get(attr)
         self._info[attr] = setting
 
         return setting


### PR DESCRIPTION
attr may not exist in the response, so this uses .get() which will
return None instead of throwing a KeyError.

This was found from a regression where hum_setpoint was being queried on
a thermostat that doesn't support humidity control (T7850). In this
particular case, the tstat is returning 200/success, but the attribute,
e.g. hum_setpoint, is not in the response:

(Pdb) p r
<Response [200]>
(Pdb) p r.json()
{'success': True}
(Pdb) p attr
'dehum_setpoint'
(Pdb) attr in r.json()
False

Fixes https://github.com/hpeyerl/venstar_colortouch/issues/42