### PR TITLE
some thermostats don't have a firmware key

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -111,6 +111,8 @@ class VenstarColorTouch:
             self._api_ver = j["api_ver"]
             if "firmware" in j:
                 self._firmware_ver = tuple(map(int, j["firmware"].split(".")))
+            else:
+                self._firmware_ver = (0,0)
             logging.debug("api_ver: %s" % self._api_ver)
             self._type = j["type"]
             if "model" in j:


### PR DESCRIPTION
Some thermostats like my Colortouch do not have a firmware key.  This is a simple check to keep it from crashing.