### PR TITLE
Bump version to 0.19 for firmware key fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG:=venstarcolortouch
 # can't handle the import so force the version.  XXX(hp).
 #
 #VERSION:=${shell ${PYTHON} src/${PKG}/__init__.py}
-VERSION=0.18
+VERSION=0.19
 
 all: clean build test
 

--- a/src/venstarcolortouch/__init__.py
+++ b/src/venstarcolortouch/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "0.18"
+__version__ = "0.19"
 
 __uri__ = 'https://github.com/hpeyerl/venstar_colortouch'
 __title__ = "venstarcolortouch"


### PR DESCRIPTION
After the firmware key check was fixed in #44, the package version remained the same, so any downstream project relying upon package management versioning, won't receive the patch. The one I'm thinking of in particular is Home Assistant.

This PR simply bumps the version number from 0.18 to 0.19, so a rebuild and push to PyPI can also be facilitated. Hopefully that's okay, and you didn't have any further changes in mind before incrementing versions. Thanks for your help.