### PR TITLE
Add T3800 Thermostat

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -224,7 +224,7 @@ class VenstarColorTouch:
             # Always degC for firmware <= 5.28
             self.tempunits = self.TEMPUNITS_C
             logging.debug("Detected thermostat model %s, using temp units of Celsius", self.model)
-        elif (self.model in ["VYG-4900-VEN", "VYG-4800-VEN", "VYG-3900", "COLORTOUCH"] or
+        elif (self.model in ["VYG-4900-VEN", "VYG-4800-VEN", "VYG-3800", "VYG-3900", "COLORTOUCH"] or
               self.model.startswith(("T2", "T3"))):
             # Same as display units
             self.tempunits = self.display_tempunits
@@ -268,7 +268,7 @@ class VenstarColorTouch:
             return self.get_info(attr)
 
         # some models only return settings at this endpoint
-        r = self._request(f"/settings?q={attr}") 
+        r = self._request(f"/settings?q={attr}")
         if not r:
             return None
 


### PR DESCRIPTION
Adding the T3800 thermostat.

Example `http://IP/` output:
`{"api_ver":7,"type":"residential","model":"VYG-3800","firmware":"2.23.19"}`

Example `http://IP/query/info` output:
`{"name":"","mode":2,"state":0,"fan":0,"fanstate":0,"tempunits":0,"schedule":0,"schedulepart":1,"away":0,"spacetemp":76,"heattemp":75,"cooltemp":77,"cooltempmin":70,"cooltempmax":99,"heattempmin":36,"heattempmax":74,"setpointdelta":2,"activestage":0,"hum_active":0,"hum":0,"hum_setpoint":0,"dehum_setpoint":99,"availablemodes":0}`

Relates to: https://github.com/home-assistant/core/issues/115903