### PR TITLE
Add support for get_info() with no arguments to return full info dict

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -260,7 +260,9 @@ class VenstarColorTouch:
             return True
         return False
 
-    def get_info(self, attr):
+    def get_info(self, attr=None):
+        if attr is None:
+            return self._info.copy()
         return self._info[attr]
 
     def get_settings(self, attr):


### PR DESCRIPTION
The original class documentation or usage context indicated that get_info() could be called without arguments to return the entire internal dictionary (_info). However, this behavior was not implemented — only the get_info(attr) form existed, which caused a TypeError when called without arguments.

This PR:

Adds support for get_info() with no arguments, returning a shallow copy of _info.

Preserves the existing functionality of get_info(attr) to retrieve individual fields.

Combines both into a single method using an optional attr parameter.