### PR TITLE
add round() call to guard against excessively precise temperatures angering the ColorTouch T8900

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -392,8 +392,11 @@ class VenstarColorTouch:
             self.log.warning("In auto mode, the cool temp must be {0} "
                   "degrees warmer than the heat temp.".format(self.setpointdelta))
             return False
-        self.heattemp = heattemp
-        self.cooltemp = cooltemp
+        # Round to two decimal places because
+        # ColorTouch T8900 (and possibly others) throws "Both Setpoints are required" 
+        # if a heat or cool temp with 3 decimal places or more is sent 
+        self.heattemp = round(heattemp, 2)
+        self.cooltemp = round(cooltemp, 2)
         data = urllib.parse.urlencode({'heattemp':self.heattemp, 'cooltemp':self.cooltemp})
         return self.set_control(data)
 


### PR DESCRIPTION
Home Assistant versions 2024.12.0 and newer started passing around extremely long floating point values for heat and cool temperatures (e.g. 73.03999999999999). 

I started seeing `{"error":true,"reason":"Both Setpoints are required"}` in the HA logs and after some trial and error in Postman I found that my ColorTouch T8900 throws that message back at me if the heat or cool temp has more than 2 decimal places. 

When I discovered it was the thermostat rejecting the value and that HA was using this library I figured the best place to add rounding was here, not in HA.

========

Try it yourself and see if it breaks your thermostat with the following two cURL command lines.

Command: `curl --location '172.17.1.10/control' --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'cooltemp=73.03999999999999' --data-urlencode 'heattemp=78'`

Result: `{"error":true,"reason":"Both Setpoints are required"}`

Command: `curl --location '172.17.1.10/control' --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'cooltemp=73.039' --data-urlencode 'heattemp=78'`

Result: `{"error":true,"reason":"Both Setpoints are required"}`


Command: `curl --location '172.17.1.10/control' --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'cooltemp=73.04' --data-urlencode 'heattemp=78'`

Result: `{"success":true}`

========

If you merge this as 0.21 I'll go open a PR under Home Assistant to upgrade (they're on 0.19).
