### PR TITLE
Update venstarcolortouch.py for model TOUCHSCREEN

### DIFF
--- a/src/venstarcolortouch/venstarcolortouch.py
+++ b/src/venstarcolortouch/venstarcolortouch.py
@@ -224,7 +224,7 @@ class VenstarColorTouch:
             # Always degC for firmware <= 5.28
             self.tempunits = self.TEMPUNITS_C
             logging.debug("Detected thermostat model %s, using temp units of Celsius", self.model)
-        elif (self.model in ["VYG-4900-VEN", "VYG-4800-VEN", "VYG-3800", "VYG-3900", "COLORTOUCH"] or
+        elif (self.model in ["VYG-4900-VEN", "VYG-4800-VEN", "VYG-3800", "VYG-3900", "COLORTOUCH", "TOUCHSCREEN"] or
               self.model.startswith(("T2", "T3"))):
             # Same as display units
             self.tempunits = self.display_tempunits


### PR DESCRIPTION
This adds "TOUCHSCREEN" to the recognized model strings. Without this, the library logs:
Unknown thermostat model TOUCHSCREEN, inferring API tempunits of Fahrenheit even though /query/info reports tempunits. Example device root payload: {"api_ver":9,"type":"residential","model":"TOUCHSCREEN","firmware":"6.93"} The change prevents the warning while keeping existing behavior unchanged. Related: Home Assistant users see the warning at venstarcolortouch.py:233.